### PR TITLE
Add Pandas.jl

### DIFF
--- a/src/IterableTables.jl
+++ b/src/IterableTables.jl
@@ -31,5 +31,6 @@ include("integrations/vegalite.jl")
 include("integrations/differentialequations.jl")
 include("integrations/generators.jl")
 include("integrations/temporal.jl")
+include("integrations/pandas.jl")
 
 end # module

--- a/src/integrations/pandas.jl
+++ b/src/integrations/pandas.jl
@@ -1,0 +1,15 @@
+@require Pandas begin
+using DataValues
+
+isiterable(x::Pandas.DataFrame) = true
+isiterabletable(x::Pandas.DataFrame) = true
+
+function getiterator(df::Pandas.DataFrame)
+    col_names = [Symbol(i) for i in Pandas.columns(df)]
+
+    columns = [Pandas.values(df[i]) for i in col_names]
+
+    return create_tableiterator(columns, col_names)
+end
+
+end


### PR DESCRIPTION
@malmaud This makes a Pandas.jl DataFrame an IterableTables.jl source. There are still some issues:

- When I call ``values(df[i])`` on a column with strings, I don't seem to get a ``Vector{String}``, but instead this:
````julia
julia> df
   age   name
0   27  James
1   29   Jill
2   27   Jake


julia> values(df[:name])
3-element Array{Ptr{PyCall.PyObject_struct},1}:
 Ptr{PyCall.PyObject_struct} @0x0000000026f58e90
 Ptr{PyCall.PyObject_struct} @0x0000000026f58dc8
 Ptr{PyCall.PyObject_struct} @0x0000000026f58f58
````
Any way for me to get a normal ``Vector{String}`` there?
- Also, what would I get for a column that has missing values?

I'll look at making it a sink soonish.