### PR TITLE
cover PooledDataArrays

### DIFF
--- a/src/integrations/dataframes.jl
+++ b/src/integrations/dataframes.jl
@@ -20,7 +20,7 @@ function TableTraits.getiterator(df::DataFrames.DataFrame)
     col_expressions = Array{Expr,1}()
     df_columns_tuple_type = Expr(:curly, :Tuple)
     for i in 1:length(df.columns)
-        if isa(df.columns[i], DataArray)
+        if isa(df.columns[i], AbstractDataArray)
             push!(col_expressions, Expr(:(::), names(df)[i], DataValue{eltype(df.columns[i])}))
         else
             push!(col_expressions, Expr(:(::), names(df)[i], eltype(df.columns[i])))
@@ -104,7 +104,7 @@ function _DataFrame(x)
     end
 
     column_types = TableTraits.column_types(iter)
-    column_names = TableTraits.column_names(iter)    
+    column_names = TableTraits.column_names(iter)
 
     columns = []
     for t in column_types
@@ -125,7 +125,7 @@ DataFrames.DataFrame{T<:NamedTuple}(x::Array{T,1}) = _DataFrame(x)
 
 function DataFrames.DataFrame(x)
     if isiterabletable(x)
-        return _DataFrame(x)        
+        return _DataFrame(x)
     else
         return convert(DataFrames.DataFrame, x)
     end


### PR DESCRIPTION
On master:
```julia
julia> using IterableTables, DataFrames, IndexedTables, RDatasets
julia> iris = dataset("datasets","iris")
julia> iris[:Species][2] = NA
julia> IndexedTable(iris)
ERROR: MethodError: Cannot `convert` an object of type DataArrays.NAtype to an object of type String
This may have arisen from a call to the constructor String(...),
since type constructors fall back to convert methods.
```

with this PR:

```julia
julia> IndexedTable(iris)
SepalLength  SepalWidth  PetalLength  PetalWidth │ Species
─────────────────────────────────────────────────┼────────────
4.3          3.0         1.1          0.1        │ "setosa"
4.4          2.9         1.4          0.2        │ "setosa"
4.4          3.0         1.3          0.2        │ "setosa"
4.4          3.2         1.3          0.2        │ "setosa"
4.5          2.3         1.3          0.3        │ "setosa"
4.6          3.1         1.5          0.2        │ "setosa"
4.6          3.2         1.4          0.2        │ "setosa"
4.6          3.4         1.4          0.3        │ "setosa"
4.6          3.6         1.0          0.2        │ "setosa"
4.7          3.2         1.3          0.2        │ "setosa"
                                                 ⋮
7.2          3.2         6.0          1.8        │ "virginica"
7.2          3.6         6.1          2.5        │ "virginica"
7.3          2.9         6.3          1.8        │ "virginica"
7.4          2.8         6.1          1.9        │ "virginica"
7.6          3.0         6.6          2.1        │ "virginica"
7.7          2.6         6.9          2.3        │ "virginica"
7.7          2.8         6.7          2.0        │ "virginica"
7.7          3.0         6.1          2.3        │ "virginica"
7.7          3.8         6.7          2.2        │ "virginica"
7.9          3.8         6.4          2.0        │ "virginica"
```

I'm not sure the solution is as simple as this (I don't know this package well), but the issue here is that `PooledDataArray` is not a `DataArray` but can also hold missing data, luckily the abstract type `AbstractDataArray` covers both cases.