### PR TITLE
simplify statsmodels integration

### DIFF
--- a/src/integrations/statsmodels-missing.jl
+++ b/src/integrations/statsmodels-missing.jl
@@ -8,18 +8,8 @@ function StatsModels.ModelFrame(f::StatsModels.Formula, d; kwargs...)
     StatsModels.ModelFrame(f, DataFrames.DataFrame(d); kwargs...)
 end
 
-function StatsBase.fit{T<:StatsBase.StatisticalModel}(::Type{T}, f::StatsModels.Formula, source, args...; contrasts::Dict = Dict(), kwargs...)
-    isiterabletable(source) || error()
-    mf = StatsModels.ModelFrame(f, source, contrasts=contrasts)
-    mm = StatsModels.ModelMatrix(mf)
-    y = StatsBase.model_response(mf)
-    StatsModels.DataFrameStatisticalModel(StatsBase.fit(T, mm.m, y, args...; kwargs...), mf, mm)
-end
-
-function StatsBase.fit{T<:StatsBase.RegressionModel}(::Type{T}, f::StatsModels.Formula, source, args...; contrasts::Dict = Dict(), kwargs...)
-    isiterabletable(source) || error()
-    mf = StatsModels.ModelFrame(f, source, contrasts=contrasts)
-    mm = StatsModels.ModelMatrix(mf)
-    y = StatsBase.model_response(mf)
-    StatsModels.DataFrameRegressionModel(StatsBase.fit(T, mm.m, y, args...; kwargs...), mf, mm)
+function StatsBase.fit(::Type{T}, f::StatsModels.Formula, d, args...; contrasts::Dict = Dict(), kwargs...) where
+                       T<:Union{StatsBase.StatisticalModel, StatsBase.RegressionModel}
+    isiterabletable(d) || error()
+    StatsBase.fit(T, f, DataFrames.DataFrame(d), args...; contrasts = contrasts, kwargs...)
 end


### PR DESCRIPTION
The code to fit `StatisticalModel` and `RegressionModel` changed a bit in StatsModels to accomodate models without intercept (see [here](https://github.com/JuliaStats/StatsModels.jl/pull/47/files#diff-e3144c4352b33632fb4a47e1dd4d063bR67)). I think that instead of changing every time StatsModels changes, it's probably simpler to convert to a DataFrame as soon as the `fit` function is called.