### PR TITLE
Load DataFrames integration only for old versions of DataFrames

### DIFF
--- a/src/IterableTables.jl
+++ b/src/IterableTables.jl
@@ -10,7 +10,9 @@ include("integrations/generators.jl")
 # include("integrations/temporal.jl")
 
 function __init__()
-    @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" include("integrations/dataframes.jl")
+    @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" if !isdefined(DataFrames, :Tables)
+        include("integrations/dataframes.jl")
+    end
     @require StatsModels="3eaba693-59b7-5ba5-a881-562e759f1c8d" include("integrations/statsmodels.jl")
 end
 


### PR DESCRIPTION
@quinnj, I think this is a more robust version than #84, right? Given that we can't use version ranges for the things in a ``@require`` file, we still need the integration in this package here to load for DataFrames.jl versions that don't yet have the Tables.jl integration. I think this code here achieves that?

It also would make it very easy to phase all of this in: we can merge this here first and tag a release, and then tag a DataFrames.jl release, and there won't even be a short time in between where things won't work.

When I ran the tests here with the new Tables.jl version of DataFrames.jl, some tests didn't pass, though. I'll write down the details of that in the DataFrames.jl PR, because I think it would have to be fixed there.